### PR TITLE
Reorganize prize priority

### DIFF
--- a/slotmachine/js/main.js
+++ b/slotmachine/js/main.js
@@ -165,6 +165,12 @@ function determineWinnings()
         else if (sevens == 3) {
             winnings = playerBet * 100;
         }
+        else if (bells == 2) {
+            winnings = playerBet * 10;
+        }
+        else if (sevens == 1) {
+            winnings = playerBet * 5;
+        }
         else if (grapes == 2) {
             winnings = playerBet * 2;
         }
@@ -180,14 +186,8 @@ function determineWinnings()
         else if (bars == 2) {
             winnings = playerBet * 5;
         }
-        else if (bells == 2) {
-            winnings = playerBet * 10;
-        }
         else if (sevens == 2) {
             winnings = playerBet * 20;
-        }
-        else if (sevens == 1) {
-            winnings = playerBet * 5;
         }
         else {
             winnings = playerBet * 1;


### PR DESCRIPTION
Single sevens are more valuable than most double fruits.
So if a user spins a grape, grape, seven, the user should receive back `playerBet * 5` not `playerBet * 2`.

In order to achieve this, the `else if (sevens == 1)` clause was moved earlier in the if/else statements.
The `else if (bells == 2)` clause was moved earlier as well because double bells are more valuable than single sevens.
So if a user spins a bell, bell, seven, the user should receive back `playerBet * 10`.

Resolves #1
